### PR TITLE
Update terminal and testreport icons

### DIFF
--- a/Extension/background.js
+++ b/Extension/background.js
@@ -31,21 +31,14 @@ function isNumeric(n) {
 }
 
 function getText(url, format) {
-
   var addressArray = url.split("/")
-
   var htmlFormat = ""
-
   var runningUrl = ""
-
   var foundJob = false
-
   var textFormat = ""
-
   var separator = ">"
 
   addressArray.forEach(it => {
-    
     if (runningUrl) {
         runningUrl += `/${it}`
     } else {
@@ -55,13 +48,11 @@ function getText(url, format) {
     if (foundJob && "job" != it && "junit" != it) {
 
       var displayText = it.replaceAll("%20", " ")
-
       if (isNumeric(displayText)) {
           displayText = "#" + displayText
       }
 
       if (displayText) {
-        
         var link
         if (format === "MARKDOWN") {
             link = `[${displayText}](${runningUrl})`
@@ -80,9 +71,7 @@ function getText(url, format) {
         }
 
         textFormat += displayText
-
         htmlFormat += link
-    
       }
 
     } else if ("job" === it) {

--- a/Extension/content_script.js
+++ b/Extension/content_script.js
@@ -29,7 +29,7 @@ function addBuildLinks(trElement) {
   addConsoleHtml(tdFailedBuild);
 }
 
-const clipboardIcon = '<img alt="Results" src="/jenkins/static/ead2b369/images/24x24/clipboard.png" style="width: 24px; height: 24px; width: 24px; height: 24px; margin: 2px;" class="icon-clipboard icon-md">';
+const clipboardIcon = '<svg class="icon-clipboard icon-md" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 512 512"><title></title><path d="M336 64h32a48 48 0 0148 48v320a48 48 0 01-48 48H144a48 48 0 01-48-48V112a48 48 0 0148-48h32" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="32"></path><rect fill="none" height="64" rx="26.13" ry="26.13" stroke="currentColor" stroke-linejoin="round" stroke-width="32" width="160" x="176" y="32"></rect></svg>';
 function addTestReportHtml(tdElement) {
   let anchors = tdElement.getElementsByTagName("a");
   if (anchors.length) {
@@ -39,7 +39,7 @@ function addTestReportHtml(tdElement) {
   }
 }
 
-const terminalIcon = '<img alt="Console" src="/jenkins/static/ead2b369/images/24x24/terminal.png" style="width: 24px; height: 24px; width: 24px; height: 24px; margin: 2px;" class="icon-terminal icon-md">';
+const terminalIcon = '<svg class="icon-terminal icon-md" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 512 512"><title></title><rect fill="none" height="416" rx="48" ry="48" stroke="currentColor" stroke-linejoin="round" stroke-width="32" width="448" x="32" y="48"></rect><path d="M96 112l80 64-80 64M192 240h64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"></path></svg>';
 function addConsoleHtml(tdElement) {
   let anchor = tdElement.getElementsByTagName("a");
   if (anchor.length) {

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ below:
 * Copy Breadcrumb as Jira Format <kbd>Alt+J</kbd>
 * Copy Breadcrumb as HTML <kbd>Alt+H</kbd>
 
-----
-The extension is tied to the Jenkin's servers at Agfa Healthcare, and won't work on
+---
+The extension is tied to the Jenkins servers at Agfa Healthcare, and won't work on
 other Jenkins instances.
+
+--- 
+
+# Testing out the extension
+
+1. Go to manage extension in your flavour of chrome. I use edge, so its 
+   * edge://extensions/
+2. First enable 'Developer mode', its a toggle on the left
+3. Click the 'Load unpacked' button
+4. Navigate to the './Extension' directory in your project and click 'Select Folder'
+
+Once you've done that you should be able to use the extension


### PR DESCRIPTION
The URLS for the icons in Jenkins are no longer available in the latest version of Jenkins so I've updated them to be svg icons that are now used by Jenkins.

I also updated the README.md to include instructions on how to test the extensions. 

I also did some minor formatting updates to the background.js file.